### PR TITLE
Add encryption interface and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Crypto Universal
+
+Crypto Universal provides a minimal encryption interface that can be
+layered on top of any messaging software.  It exposes simple functions to
+encrypt and decrypt messages so they can be copied into or out of your
+favourite communication app.
+
+The library uses asymmetric RSA encryption from the
+[`cryptography`](https://cryptography.io/) package. A private/public key
+pair can be generated once and reused across messaging apps.
+
+## Installation
+
+```
+pip install cryptography
+```
+
+## Usage
+
+Generate a key pair:
+
+```
+python -m crypto_universal generate-keys
+```
+
+The first line of output is the base64 encoded private key and the second
+line is the base64 encoded public key.  Encrypt a message:
+
+```
+python -m crypto_universal encrypt <base64-public-key> "hello"
+```
+
+Decrypt a message:
+
+```
+python -m crypto_universal decrypt <base64-private-key> <ciphertext>
+```
+
+You can integrate these calls into a custom keyboard or other overlay so
+that messages are automatically encrypted before being sent and decrypted
+when received.

--- a/src/crypto_universal/__init__.py
+++ b/src/crypto_universal/__init__.py
@@ -1,0 +1,5 @@
+"""Public API for Crypto Universal."""
+
+from .interface import MessagingCrypto, generate_keypair
+
+__all__ = ["MessagingCrypto", "generate_keypair"]

--- a/src/crypto_universal/__main__.py
+++ b/src/crypto_universal/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/crypto_universal/cli.py
+++ b/src/crypto_universal/cli.py
@@ -1,0 +1,40 @@
+import argparse
+import base64
+
+from .interface import MessagingCrypto, generate_keypair
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Crypto Universal CLI")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("generate-keys")
+
+    enc = sub.add_parser("encrypt")
+    enc.add_argument("public_key", help="base64 encoded public key")
+    enc.add_argument("message", help="plaintext message")
+
+    dec = sub.add_parser("decrypt")
+    dec.add_argument("private_key", help="base64 encoded private key")
+    dec.add_argument("token", help="base64 ciphertext")
+
+    args = parser.parse_args()
+
+    if args.command == "generate-keys":
+        priv, pub = generate_keypair()
+        print(base64.b64encode(priv).decode("utf-8"))
+        print(base64.b64encode(pub).decode("utf-8"))
+    elif args.command == "encrypt":
+        pub = base64.b64decode(args.public_key.encode("utf-8"))
+        mc = MessagingCrypto.from_pem(public_pem=pub)
+        print(mc.encrypt(args.message))
+    elif args.command == "decrypt":
+        priv = base64.b64decode(args.private_key.encode("utf-8"))
+        mc = MessagingCrypto.from_pem(private_pem=priv)
+        print(mc.decrypt(args.token))
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/crypto_universal/interface.py
+++ b/src/crypto_universal/interface.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Tuple
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+
+def generate_keypair() -> Tuple[bytes, bytes]:
+    """Generate a new RSA private/public key pair.
+
+    Returns a tuple ``(private_pem, public_pem)`` containing the keys in PEM
+    format.
+    """
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    private_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    public_pem = public_key.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+@dataclass
+class MessagingCrypto:
+    """Wrapper for asymmetric RSA encryption and decryption."""
+
+    private_key: rsa.RSAPrivateKey | None = None
+    public_key: rsa.RSAPublicKey | None = None
+
+    def __post_init__(self) -> None:
+        if self.private_key is None and self.public_key is None:
+            raise ValueError("At least one of private_key or public_key is required")
+        if self.private_key and not self.public_key:
+            self.public_key = self.private_key.public_key()
+
+    @classmethod
+    def from_pem(cls, private_pem: bytes | None = None, public_pem: bytes | None = None) -> "MessagingCrypto":
+        private = (
+            serialization.load_pem_private_key(private_pem, password=None)
+            if private_pem
+            else None
+        )
+        public = (
+            serialization.load_pem_public_key(public_pem) if public_pem else None
+        )
+        return cls(private_key=private, public_key=public)
+
+    def encrypt(self, plaintext: str) -> str:
+        if not self.public_key:
+            raise ValueError("Public key is required for encryption")
+        ciphertext = self.public_key.encrypt(
+            plaintext.encode("utf-8"),
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None,
+            ),
+        )
+        return base64.b64encode(ciphertext).decode("utf-8")
+
+    def decrypt(self, token: str) -> str:
+        if not self.private_key:
+            raise ValueError("Private key is required for decryption")
+        ciphertext = base64.b64decode(token.encode("utf-8"))
+        plaintext = self.private_key.decrypt(
+            ciphertext,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None,
+            ),
+        )
+        return plaintext.decode("utf-8")

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+# ensure src directory is on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from crypto_universal.interface import generate_keypair, MessagingCrypto
+
+
+def test_roundtrip():
+    priv, pub = generate_keypair()
+    mc_enc = MessagingCrypto.from_pem(public_pem=pub)
+    mc_dec = MessagingCrypto.from_pem(private_pem=priv)
+    plaintext = "secret message"
+    token = mc_enc.encrypt(plaintext)
+    assert mc_dec.decrypt(token) == plaintext


### PR DESCRIPTION
## Summary
- provide RSA encryption interface
- switch CLI to use RSA key pairs
- document new workflow in README
- update unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846bee129e4832eb1fba56a1d7889c5