### PR TITLE
Add encrypted key storage and management

### DIFF
--- a/build_android.py
+++ b/build_android.py
@@ -1,10 +1,17 @@
 import argparse
 import base64
+import getpass
 import shutil
 import subprocess
 from pathlib import Path
 
+from cryptography.hazmat.primitives import serialization
+
 from src.crypto_universal.interface import generate_keypair
+from src.crypto_universal.key_storage import (
+    load_private_key_encrypted,
+    save_private_key_encrypted,
+)
 
 
 def build_project(user: str, key_file: Path, install: bool) -> None:
@@ -30,23 +37,37 @@ def build_project(user: str, key_file: Path, install: bool) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Build and install the Android app")
     parser.add_argument("--user", required=True, help="username for build directory")
-    parser.add_argument("--key", help="path to public key file")
+    parser.add_argument("--public", help="path to public key file")
+    parser.add_argument(
+        "--private", default="private_key.enc", help="encrypted private key path"
+    )
     parser.add_argument("--install", action="store_true", help="install the APK with adb")
     args = parser.parse_args()
 
-    if args.key:
-        key_path = Path(args.key)
+    pub_file = Path(args.public) if args.public else Path("public_key.txt")
+    priv_file = Path(args.private)
+
+    if priv_file.exists():
+        password = getpass.getpass("Private key password: ")
+        priv_pem = load_private_key_encrypted(priv_file, password)
+        priv = serialization.load_pem_private_key(priv_pem, password=None)
+        pub_pem = priv.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
     else:
-        priv, pub = generate_keypair()
-        key_path = Path("public_key.txt")
-        key_path.write_bytes(base64.b64encode(pub))
-        print("Generated new key pair. Private key:\n" + base64.b64encode(priv).decode())
-        print("Public key written to", key_path)
+        priv_pem, pub_pem = generate_keypair()
+        password = getpass.getpass("Create password for private key: ")
+        save_private_key_encrypted(priv_pem, priv_file, password)
+        print(f"Encrypted private key saved to {priv_file}")
 
-    build_project(args.user, key_path, args.install)
+    pub_file.write_bytes(base64.b64encode(pub_pem))
+    print("Public key written to", pub_file)
 
-    if not args.key:
-        key_path.unlink()
+    build_project(args.user, pub_file, args.install)
+
+    if not args.public:
+        pub_file.unlink()
 
 
 if __name__ == "__main__":

--- a/keymanager.py
+++ b/keymanager.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import getpass
+from pathlib import Path
+
+from src.crypto_universal.interface import generate_keypair, MessagingCrypto
+from src.crypto_universal.key_storage import (
+    save_private_key_encrypted,
+    load_private_key_encrypted,
+)
+
+
+def _prompt_password(confirm: bool = False) -> str:
+    pwd = getpass.getpass("Password: ")
+    if confirm:
+        if pwd != getpass.getpass("Confirm: "):
+            raise ValueError("Passwords do not match")
+    return pwd
+
+
+def cmd_generate(args: argparse.Namespace) -> None:
+    priv, pub = generate_keypair()
+    password = _prompt_password(confirm=True)
+    save_private_key_encrypted(priv, args.path, password)
+    print(f"Encrypted private key written to {args.path}")
+    if args.public_out:
+        Path(args.public_out).write_bytes(base64.b64encode(pub))
+        print(f"Public key written to {args.public_out}")
+    else:
+        print(base64.b64encode(pub).decode())
+
+
+def cmd_show(args: argparse.Namespace) -> None:
+    password = _prompt_password()
+    priv = load_private_key_encrypted(args.path, password)
+    print(base64.b64encode(priv).decode())
+
+
+def cmd_decrypt(args: argparse.Namespace) -> None:
+    password = _prompt_password()
+    priv = load_private_key_encrypted(args.path, password)
+    mc = MessagingCrypto.from_pem(private_pem=priv)
+    token = Path(args.infile).read_text().strip()
+    plaintext = mc.decrypt(token)
+    Path(args.out).write_text(plaintext)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Private key manager")
+    sub = parser.add_subparsers(dest="cmd")
+
+    g = sub.add_parser("generate")
+    g.add_argument("--path", default="private.key", help="Encrypted key path")
+    g.add_argument("--public-out", help="File to write public key")
+
+    s = sub.add_parser("show")
+    s.add_argument("--path", default="private.key", help="Encrypted key path")
+
+    d = sub.add_parser("decrypt")
+    d.add_argument("--path", default="private.key", help="Encrypted key path")
+    d.add_argument("--in", dest="infile", required=True, help="Ciphertext file")
+    d.add_argument("--out", required=True, help="Plaintext output file")
+
+    args = parser.parse_args()
+    if args.cmd == "generate":
+        cmd_generate(args)
+    elif args.cmd == "show":
+        cmd_show(args)
+    elif args.cmd == "decrypt":
+        cmd_decrypt(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [project.scripts]
 crypto_universal = "crypto_universal.cli:main"
+keymanager = "keymanager:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/crypto_universal/__init__.py
+++ b/src/crypto_universal/__init__.py
@@ -1,5 +1,11 @@
 """Public API for Crypto Universal."""
 
 from .interface import MessagingCrypto, generate_keypair
+from .key_storage import load_private_key_encrypted, save_private_key_encrypted
 
-__all__ = ["MessagingCrypto", "generate_keypair"]
+__all__ = [
+    "MessagingCrypto",
+    "generate_keypair",
+    "save_private_key_encrypted",
+    "load_private_key_encrypted",
+]

--- a/src/crypto_universal/key_storage.py
+++ b/src/crypto_universal/key_storage.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Union
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+
+
+def _derive_key(password: str, salt: bytes) -> bytes:
+    kdf = Scrypt(salt=salt, length=32, n=2**14, r=8, p=1)
+    return kdf.derive(password.encode("utf-8"))
+
+
+def save_private_key_encrypted(key: bytes, path: Union[str, Path], password: str) -> None:
+    """Encrypt ``key`` with ``password`` and save to ``path``.
+
+    The file format is ``salt || iv || tag || ciphertext``.
+    """
+    path = Path(path)
+    salt = os.urandom(16)
+    sym_key = _derive_key(password, salt)
+    iv = os.urandom(12)
+    aesgcm = AESGCM(sym_key)
+    ct = aesgcm.encrypt(iv, key, None)
+    ciphertext, tag = ct[:-16], ct[-16:]
+    with open(path, "wb") as fh:
+        fh.write(salt + iv + tag + ciphertext)
+
+
+def load_private_key_encrypted(path: Union[str, Path], password: str) -> bytes:
+    """Load and decrypt private key stored at ``path`` using ``password``."""
+    data = Path(path).read_bytes()
+    if len(data) < 44:
+        raise ValueError("Invalid encrypted key file")
+    salt = data[:16]
+    iv = data[16:28]
+    tag = data[28:44]
+    ciphertext = data[44:]
+    sym_key = _derive_key(password, salt)
+    aesgcm = AESGCM(sym_key)
+    return aesgcm.decrypt(iv, ciphertext + tag, None)

--- a/tests/test_key_storage.py
+++ b/tests/test_key_storage.py
@@ -1,0 +1,25 @@
+import base64
+from pathlib import Path
+
+from crypto_universal.interface import generate_keypair, MessagingCrypto
+from crypto_universal.key_storage import save_private_key_encrypted, load_private_key_encrypted
+
+
+def test_key_roundtrip(tmp_path):
+    priv, pub = generate_keypair()
+    key_file = tmp_path / "priv.enc"
+    save_private_key_encrypted(priv, key_file, "pw")
+    loaded = load_private_key_encrypted(key_file, "pw")
+    assert loaded == priv
+
+
+def test_integration_decrypt(tmp_path):
+    priv, pub = generate_keypair()
+    key_file = tmp_path / "priv.enc"
+    save_private_key_encrypted(priv, key_file, "pw")
+    mc_enc = MessagingCrypto.from_pem(public_pem=pub)
+    mc_dec_priv = load_private_key_encrypted(key_file, "pw")
+    mc_dec = MessagingCrypto.from_pem(private_pem=mc_dec_priv)
+    token = mc_enc.encrypt("hello")
+    assert mc_dec.decrypt(token) == "hello"
+


### PR DESCRIPTION
## Summary
- implement AES-256-GCM key encryption helpers
- add a `keymanager.py` CLI for managing encrypted keys
- update Android build script to use encrypted private key
- expose new helpers via package init
- register new CLI entry point and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d505204c832eba570d09d6dacd81